### PR TITLE
Centralize API base URL constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Backend URL Configuration
+
+The frontend communicates with a backend API. Set the `NEXT_PUBLIC_BACKEND_URL` environment variable to point to the correct server.
+
+- **Development:** create a `.env.local` file with `NEXT_PUBLIC_BACKEND_URL=http://localhost:5000`.
+- **Production:** set `NEXT_PUBLIC_BACKEND_URL` to your deployed backend URL (for example `https://api.example.com`).
+
+If this variable is not provided, the application defaults to `http://localhost:5000`.
 
 ## Learn More
 

--- a/src/app/appointments/page.js
+++ b/src/app/appointments/page.js
@@ -27,6 +27,7 @@ import { toast, Toaster } from "react-hot-toast";
 
 import { useAuth } from "../context/AuthContext";
 import Navbar from "../ui/Navbar";
+import { API_BASE } from "@/lib/constants";
 
 const TestDriveBooking = () => {
   const { user } = useAuth();
@@ -71,7 +72,7 @@ const TestDriveBooking = () => {
     e.preventDefault();
     console.log("formData", formData);
     try {
-      const response = await fetch("http://localhost:5000/api/test-drive", {
+      const response = await fetch(`${API_BASE}/api/test-drive`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/booking/page.js
+++ b/src/app/booking/page.js
@@ -67,6 +67,7 @@ import axios from "axios";
 import { Mail, MapPin, PhoneCall } from "lucide-react";
 import { useState } from "react";
 import Navbar from "../ui/Navbar";
+import { API_BASE } from "@/lib/constants";
 
 const Page = () => {
   // States for managing form data
@@ -96,7 +97,7 @@ const Page = () => {
 
     try {
       const response = await axios.post(
-        "http://localhost:5000/api/book",
+        `${API_BASE}/api/book`,
         formData
       );
       setMessage(response.data.message); // Display success message

--- a/src/app/cars/[id]/page.js
+++ b/src/app/cars/[id]/page.js
@@ -23,6 +23,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import Navbar from "../../ui/Navbar";
+import { API_BASE } from "@/lib/constants";
 import {
   Carousel,
   CarouselContent,
@@ -40,11 +41,7 @@ export default function CarDetailsPage() {
   useEffect(() => {
     const fetchCarDetails = async () => {
       try {
-        const response = await fetch(
-          `${
-            process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000"
-          }/api/cars/${params.id}`
-        );
+        const response = await fetch(`${API_BASE}/api/cars/${params.id}`);
         if (!response.ok) {
           throw new Error("Failed to fetch car details");
         }

--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -37,6 +37,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "../context/AuthContext";
 import Navbar from "../ui/Navbar";
+import { API_BASE } from "@/lib/constants";
 
 const ContactUs = () => {
   const router = useRouter();
@@ -63,7 +64,7 @@ const ContactUs = () => {
     };
 
     try {
-      const response = await fetch("http://localhost:5000/api/submit", {
+      const response = await fetch(`${API_BASE}/api/submit`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/context/AuthContext.js
+++ b/src/app/context/AuthContext.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect } from "react";
+import { API_BASE } from "@/lib/constants";
 
 const AuthContext = createContext();
 
@@ -13,7 +14,7 @@ export function AuthProvider({ children }) {
       try {
         console.log('Checking auth status...');
         const response = await fetch(
-          "http://localhost:5000/users/current-user",
+          `${API_BASE}/users/current-user`,
           {
             credentials: "include",
             headers: {

--- a/src/app/dashboard/admin/chat/page.js
+++ b/src/app/dashboard/admin/chat/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '@/app/context/AuthContext';
 import { useRouter } from 'next/navigation';
 import { io } from 'socket.io-client';
+import { API_BASE } from '@/lib/constants';
 import { Send, Loader2, AlertCircle, MessageSquare, ArrowLeft, Trash2 } from 'lucide-react';
 
 export default function AdminChatPage() {
@@ -87,7 +88,7 @@ export default function AdminChatPage() {
     const fetchConversations = async () => {
       try {
         setLoading(prev => ({ ...prev, conversations: true }));
-        const response = await fetch('http://localhost:5000/api/admin-chat/conversations', {
+        const response = await fetch(`${API_BASE}/api/admin-chat/conversations`, {
           credentials: 'include',
           headers: {
             'Content-Type': 'application/json'
@@ -108,14 +109,14 @@ export default function AdminChatPage() {
           console.log('No conversations found, creating a test conversation...');
           try {
             // Get the first non-admin user
-            const usersResponse = await fetch('http://localhost:5000/users', {
+            const usersResponse = await fetch(`${API_BASE}/users`, {
               credentials: 'include'
             });
             const users = await usersResponse.json();
             const regularUser = users.find(u => u.role === 'user');
             
             if (regularUser) {
-              const sendResponse = await fetch('http://localhost:5000/api/admin-chat/send', {
+              const sendResponse = await fetch(`${API_BASE}/api/admin-chat/send`, {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
@@ -130,7 +131,7 @@ export default function AdminChatPage() {
               if (sendResponse.ok) {
                 console.log('Test message sent successfully');
                 // Fetch conversations again to get the new conversation
-                const updatedResponse = await fetch('http://localhost:5000/api/admin-chat/conversations', {
+                const updatedResponse = await fetch(`${API_BASE}/api/admin-chat/conversations`, {
                   credentials: 'include',
                   headers: {
                     'Content-Type': 'application/json'
@@ -179,7 +180,7 @@ export default function AdminChatPage() {
     const fetchMessages = async () => {
       if (selectedConversation) {
         try {
-          const response = await fetch(`http://localhost:5000/api/admin-chat/history/${selectedConversation.userId}`, {
+          const response = await fetch(`${API_BASE}/api/admin-chat/history/${selectedConversation.userId}`, {
             credentials: 'include',
             headers: {
               'Authorization': `Bearer ${localStorage.getItem('token')}`
@@ -198,7 +199,7 @@ export default function AdminChatPage() {
           setMessages(data);
           
           // Mark messages as read
-          await fetch(`http://localhost:5000/api/admin-chat/read/${selectedConversation.userId}`, {
+          await fetch(`${API_BASE}/api/admin-chat/read/${selectedConversation.userId}`, {
             method: 'PUT',
             credentials: 'include',
             headers: {
@@ -240,7 +241,7 @@ export default function AdminChatPage() {
     setLoading(prev => ({ ...prev, sending: true }));
 
     try {
-      const response = await fetch('http://localhost:5000/api/admin-chat/send', {
+      const response = await fetch(`${API_BASE}/api/admin-chat/send`, {
         method: 'POST',
         credentials: 'include',
         headers: {

--- a/src/app/dashboard/analytics/page.js
+++ b/src/app/dashboard/analytics/page.js
@@ -11,6 +11,7 @@ import {
 import { useEffect, useState } from "react";
 import { Cell, Legend, Pie, PieChart, Tooltip, ResponsiveContainer } from "recharts";
 import Sidebar from "../../ui/Sidebar";
+import { API_BASE } from "@/lib/constants";
 import { ImageIcon, Brain, TrendingUp, AlertCircle, Upload } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import { useRouter } from "next/navigation";
@@ -53,7 +54,7 @@ const AIPredictionPage = () => {
     const fetchData = async () => {
       try {
         // Fetch cars data
-        const carsResponse = await fetch('http://localhost:5000/api/cars', {
+        const carsResponse = await fetch(`${API_BASE}/api/cars`, {
           credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
@@ -211,7 +212,7 @@ const AIPredictionPage = () => {
     setSelectedCar(car);
 
     try {
-      const response = await fetch('http://localhost:5000/api/cars/analyze-image', {
+      const response = await fetch(`${API_BASE}/api/cars/analyze-image`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/dashboard/bookings/page.js
+++ b/src/app/dashboard/bookings/page.js
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import Sidebar from "../../ui/Sidebar";
+import { API_BASE } from "@/lib/constants";
 
 const AdminTestDrives = () => {
   const [testDrives, setTestDrives] = useState([]);
@@ -32,7 +33,7 @@ const AdminTestDrives = () => {
   useEffect(() => {
     const fetchTestDrives = async () => {
       try {
-        const response = await fetch("http://localhost:5000/api/test-drives");
+        const response = await fetch(`${API_BASE}/api/test-drives`);
         if (!response.ok) {
           throw new Error("Failed to fetch test drives");
         }
@@ -65,7 +66,7 @@ const AdminTestDrives = () => {
   const handleStatusUpdate = async (id, status) => {
     try {
       const response = await fetch(
-        `http://localhost:5000/api/test-drives/${id}/status`,
+        `${API_BASE}/api/test-drives/${id}/status`,
         {
           method: "PUT",
           headers: {
@@ -89,7 +90,7 @@ const AdminTestDrives = () => {
   const handleDelete = async (id) => {
     console.log("Deleting test drive with id:", id);
     try {
-      await fetch(`http://localhost:5000/api/test-drives/${id}`, {
+      await fetch(`${API_BASE}/api/test-drives/${id}`, {
         method: "DELETE",
       });
       setTestDrives((prev) => prev.filter((drive) => drive._id !== id));

--- a/src/app/dashboard/carlisting/edit/[id]/page.js
+++ b/src/app/dashboard/carlisting/edit/[id]/page.js
@@ -18,6 +18,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeftIcon, X } from "lucide-react";
 import Link from "next/link";
+import { API_BASE } from "@/lib/constants";
 
 const EditCarPage = () => {
   const router = useRouter();
@@ -67,7 +68,7 @@ const EditCarPage = () => {
       try {
         setIsFetching(true);
         const backendUrl =
-          process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+          process.env.NEXT_PUBLIC_API_URL || API_BASE;
         const response = await fetch(`${backendUrl}/api/cars/${carId}`);
 
         if (!response.ok) {
@@ -198,7 +199,7 @@ const EditCarPage = () => {
 
     try {
       const backendUrl =
-        process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+        process.env.NEXT_PUBLIC_API_URL || API_BASE;
       const response = await fetch(`${backendUrl}/api/cars/${carId}`, {
         method: "PUT",
         // Don't set Content-Type header; browser will set it with boundary for FormData

--- a/src/app/dashboard/chat/page.js
+++ b/src/app/dashboard/chat/page.js
@@ -5,6 +5,7 @@ import { useAuth } from "@/app/context/AuthContext";
 import { useRouter } from "next/navigation";
 import { io } from "socket.io-client";
 import { Send, Loader2, AlertCircle, MessageSquare, ArrowLeft } from "lucide-react";
+import { API_BASE } from "@/lib/constants";
 
 export default function UserChatPage() {
   const { user, loading: authLoading } = useAuth();
@@ -34,7 +35,7 @@ export default function UserChatPage() {
     if (!user || user.role === "admin") return;
 
     // Initialize socket connection
-    const newSocket = io("http://localhost:5000", {
+    const newSocket = io(API_BASE, {
       withCredentials: true,
       auth: {
         token: localStorage.getItem("token")
@@ -69,7 +70,7 @@ export default function UserChatPage() {
     const fetchMessages = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`http://localhost:5000/api/chat/history/${user._id}`, {
+        const response = await fetch(`${API_BASE}/api/chat/history/${user._id}`, {
           credentials: "include",
           headers: {
             "Content-Type": "application/json"
@@ -107,7 +108,7 @@ export default function UserChatPage() {
     if (!newMessage.trim()) return;
 
     try {
-      const response = await fetch("http://localhost:5000/api/chat/send", {
+      const response = await fetch(`${API_BASE}/api/chat/send`, {
         method: "POST",
         credentials: "include",
         headers: {

--- a/src/app/dashboard/messages/page.js
+++ b/src/app/dashboard/messages/page.js
@@ -13,6 +13,7 @@ import {
 import { ChevronLeft, ChevronRight, Search, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import Sidebar from "../../ui/Sidebar";
+import { API_BASE } from "@/lib/constants";
 
 const AdminMessages = () => {
   const [messages, setMessages] = useState([]);
@@ -24,7 +25,7 @@ const AdminMessages = () => {
   useEffect(() => {
     const fetchMessages = async () => {
       try {
-        const response = await fetch("http://localhost:5000/api/messages");
+        const response = await fetch(`${API_BASE}/api/messages`);
         if (!response.ok) {
           throw new Error("Failed to fetch messages");
         }
@@ -56,7 +57,7 @@ const AdminMessages = () => {
   // Handle delete
   const handleDelete = async (id) => {
     try {
-      await fetch(`http://localhost:5000/api/delete/${id}`, {
+      await fetch(`${API_BASE}/api/delete/${id}`, {
         method: "DELETE",
       });
       setMessages((prev) => prev.filter((msg) => msg._id !== id));

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -11,6 +11,7 @@ import {
 import { MoreVertical, Package, Users, TrendingUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import Sidebar from "../ui/Sidebar";
+import { API_BASE } from "@/lib/constants";
 import {
   LineChart,
   Line,
@@ -32,8 +33,8 @@ const Dashboard = () => {
     const fetchSalesData = async () => {
       try {
         const [soldCars, monthlyData] = await Promise.all([
-          fetch("http://localhost:5000/api/cars/sold").then(res => res.json()),
-          fetch("http://localhost:5000/api/cars/sales/monthly").then(res => res.json())
+          fetch(`${API_BASE}/api/cars/sold`).then(res => res.json()),
+          fetch(`${API_BASE}/api/cars/sales/monthly`).then(res => res.json())
         ]);
 
         setSalesData(soldCars);
@@ -49,7 +50,7 @@ const Dashboard = () => {
 
     const fetchTestDriveData = async () => {
       try {
-        const data = await fetch("http://localhost:5000/api/test-drives/approve");
+        const data = await fetch(`${API_BASE}/api/test-drives/approve`);
       const jsonData = await data.json();
       setTestDriveData(jsonData);
       } catch (error) {

--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -11,6 +11,7 @@ import {
 import { MoreVertical, Package, Users, TrendingUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import Sidebar from "../ui/Sidebar";
+import { API_BASE } from "@/lib/constants";
 import {
   LineChart,
   Line,
@@ -32,8 +33,8 @@ const Dashboard = () => {
     const fetchSalesData = async () => {
       try {
         const [soldCars, monthlyData] = await Promise.all([
-          fetch("http://localhost:5000/api/cars/sold").then(res => res.json()),
-          fetch("http://localhost:5000/api/cars/sales/monthly").then(res => res.json())
+          fetch(`${API_BASE}/api/cars/sold`).then(res => res.json()),
+          fetch(`${API_BASE}/api/cars/sales/monthly`).then(res => res.json())
         ]);
 
         setSalesData(soldCars);
@@ -49,7 +50,7 @@ const Dashboard = () => {
 
     const fetchTestDriveData = async () => {
       try {
-        const data = await fetch("http://localhost:5000/api/test-drives/approve");
+        const data = await fetch(`${API_BASE}/api/test-drives/approve`);
         const jsonData = await data.json();
         setTestDriveData(jsonData);
       } catch (error) {

--- a/src/app/dashboard/users/page.js
+++ b/src/app/dashboard/users/page.js
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { useAuth } from "../../context/AuthContext";
+import { API_BASE } from "@/lib/constants";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,7 +57,7 @@ const UsersPage = () => {
   useEffect(() => {
     const fetchUsers = async () => {
       try {
-        const response = await fetch("http://localhost:5000/users", {
+        const response = await fetch(`${API_BASE}/users`, {
           credentials: "include",
         });
         if (!response.ok) {
@@ -99,7 +100,7 @@ const UsersPage = () => {
     e.preventDefault();
 
     try {
-      const response = await fetch("http://localhost:5000/users/update", {
+      const response = await fetch(`${API_BASE}/users/update`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useRouter } from "next/navigation";
+import { API_BASE } from "@/lib/constants";
 
 export default function LoginPage() {
   const { setUser } = useAuth();
@@ -19,7 +20,7 @@ export default function LoginPage() {
     // Trigger Google login
     console.log("Google login triggered");
     const backendUrl =
-      process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+      process.env.NEXT_PUBLIC_API_URL || API_BASE;
     window.location.href = `${backendUrl}/users/google`;
   };
 
@@ -28,7 +29,7 @@ export default function LoginPage() {
     e.preventDefault(); // Add this to prevent form submission
     setIsLoading(true);
     try {
-      const response = await fetch("http://localhost:5000/users/login", {
+      const response = await fetch(`${API_BASE}/users/login`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -21,6 +21,7 @@ import { useEffect, useState, useRef } from "react";
 import ProtectedRoute from "../components/ProtectedRoute";
 import { useAuth } from "../context/AuthContext";
 import Navbar from "../ui/Navbar";
+import { API_BASE } from "@/lib/constants";
 import {
   Dialog,
   DialogContent,
@@ -147,7 +148,7 @@ export default function UserProfileEdit() {
   }
   const handleLogout = async () => {
     try {
-      const response = await fetch("http://localhost:5000/users/logout", {
+      const response = await fetch(`${API_BASE}/users/logout`, {
         method: "GET",
         credentials: "include",
       });
@@ -206,7 +207,7 @@ export default function UserProfileEdit() {
 
     try {
       const response = await fetch(
-        "http://localhost:5000/users/update-password",
+        `${API_BASE}/users/update-password`,
         {
           method: "PUT",
           headers: {

--- a/src/app/signup/page.js
+++ b/src/app/signup/page.js
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { API_BASE } from "@/lib/constants";
 
 const SignUpPage = () => {
   const router = useRouter();
@@ -19,7 +20,7 @@ const SignUpPage = () => {
 
   const handleGoogleSignup = () => {
     const backendUrl =
-      process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000";
+      process.env.NEXT_PUBLIC_API_URL || API_BASE;
     window.location.href = `${backendUrl}/users/google`;
   };
 
@@ -41,7 +42,7 @@ const SignUpPage = () => {
       };
       console.log("Sending signup data:", signupData);
 
-      const response = await fetch("http://localhost:5000/users/signup", {
+      const response = await fetch(`${API_BASE}/users/signup`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/ui/FeaturedCars.js
+++ b/src/app/ui/FeaturedCars.js
@@ -3,13 +3,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { API_BASE } from "@/lib/constants";
 
 const FeaturedCars = () => {
   const [filteredCars, setFilteredCars] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  const backendUrl =
-    process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000";
+  const backendUrl = API_BASE;
 
   useEffect(() => {
     const fetchCars = async () => {

--- a/src/app/ui/LatestCarsSection.js
+++ b/src/app/ui/LatestCarsSection.js
@@ -4,12 +4,12 @@ import { Calendar, Fuel, Gauge } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { API_BASE } from "@/lib/constants";
 export default function LatestCarsSection() {
   const [latestCars, setLatestCars] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  const backendUrl =
-    process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5000";
+  const backendUrl = API_BASE;
 
   useEffect(() => {
     const fetchLatestCars = async () => {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,1 @@
+export const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';


### PR DESCRIPTION
## Summary
- add `API_BASE` constant
- use `API_BASE` in API calls
- document `NEXT_PUBLIC_BACKEND_URL` in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7b3c4a08322b30c7f734e00f5d9